### PR TITLE
Feat/dev 149 disable aliquot selection

### DIFF
--- a/aliquot_level_maf/selection.py
+++ b/aliquot_level_maf/selection.py
@@ -40,13 +40,14 @@ class PrimaryAliquotSelectionCriterion(NamedTuple):
     Attributes:
         id: Any identifier.
         samples: The samples that the aliquots came from.
-        case_id: The id of the case that the aliquot came from.
+        entity_id: A primary aliquot will be chosen
+                   per this entity (file_id, case_id, etc.).
         maf_creation_date: The date the MAF file was created in the graph.
     """
 
     id: str
     samples: List[SampleCriterion]
-    case_id: str
+    entity_id: str
     maf_creation_date: datetime.datetime
 
 
@@ -65,7 +66,10 @@ class PrimaryAliquot(NamedTuple):
 def select_primary_aliquots(
     criteria: List[PrimaryAliquotSelectionCriterion],
 ) -> Dict[str, PrimaryAliquot]:
-    """Select the primary-aliquot for each case.
+    """Select the primary-aliquot for each entity.
+
+    If disable_aliquot_selection is set, select primary aliquot per file
+    If dislabe-aliquot_selection is not set, select primary aliquot per case
 
     For primary aliquot selection, the MAFs are ranked based on sample.sample_type, in
     the following order:
@@ -88,13 +92,13 @@ def select_primary_aliquots(
         criteria: A list of selection criteria for each aliquot-level MAF
 
     Returns:
-        A dictionary of case ids to primary aliquot
+        A dictionary of entity ids to primary aliquot
     """
     if not criteria:
         return dict()
 
-    criteria_by_case = _group_criteria_by_case(_flatten(criteria))
-    return {case_id: _perform_selection(cs) for case_id, cs in criteria_by_case.items()}
+    criteria_by_entity = _group_criteria_by_entity(_flatten(criteria))
+    return {entity: _perform_selection(cs) for entity, cs in criteria_by_entity.items()}
 
 
 def _flatten(
@@ -108,20 +112,20 @@ def _flatten(
                 PrimaryAliquotSelectionCriterion(
                     id=criterion.id,
                     samples=[sample],
-                    case_id=criterion.case_id,
+                    entity_id=criterion.entity_id,
                     maf_creation_date=criterion.maf_creation_date,
                 )
             )
     return flattened
 
 
-def _group_criteria_by_case(
+def _group_criteria_by_entity(
     criteria: List[PrimaryAliquotSelectionCriterion],
 ) -> Dict[str, List[PrimaryAliquotSelectionCriterion]]:
-    criteria_by_case = defaultdict(list)
+    criteria_by_entity = defaultdict(list)
     for criterion in criteria:
-        criteria_by_case[criterion.case_id].append(criterion)
-    return criteria_by_case
+        criteria_by_entity[criterion.entity_id].append(criterion)
+    return criteria_by_entity
 
 
 def _perform_selection(

--- a/aliquot_level_maf/selection.py
+++ b/aliquot_level_maf/selection.py
@@ -68,9 +68,6 @@ def select_primary_aliquots(
 ) -> Dict[str, PrimaryAliquot]:
     """Select the primary-aliquot for each entity.
 
-    If disable_aliquot_selection is set, select primary aliquot per file
-    If dislabe-aliquot_selection is not set, select primary aliquot per case
-
     For primary aliquot selection, the MAFs are ranked based on sample.sample_type, in
     the following order:
 

--- a/tests/test_selection.py
+++ b/tests/test_selection.py
@@ -16,7 +16,7 @@ def test_select_primary_aliquots__selects_correct_sample_type():
                 SampleCriterion(id="sample_1", sample_type="Ectoplasm",),
                 SampleCriterion(id="sample_2", sample_type="Muslin"),
             ],
-            case_id="case_1",
+            entity_id="case_1",
             maf_creation_date=datetime(2020, 1, 1),
         ),
         PrimaryAliquotSelectionCriterion(
@@ -25,7 +25,7 @@ def test_select_primary_aliquots__selects_correct_sample_type():
                 SampleCriterion(id="sample_3", sample_type="Primary Tumor",),
                 SampleCriterion(id="sample_4", sample_type="Blood Derived Normal",),
             ],
-            case_id="case_1",
+            entity_id="case_1",
             maf_creation_date=datetime(2020, 1, 1),
         ),
         PrimaryAliquotSelectionCriterion(
@@ -34,7 +34,7 @@ def test_select_primary_aliquots__selects_correct_sample_type():
                 SampleCriterion(id="sample_5", sample_type="Unknown",),
                 SampleCriterion(id="sample_6", sample_type="Recurrent Tumor",),
             ],
-            case_id="case_1",
+            entity_id="case_1",
             maf_creation_date=datetime(2020, 1, 1),
         ),
     ]
@@ -51,7 +51,7 @@ def test_select_primary_aliquots__uses_maf_creation_date_to_break_tie():
                 SampleCriterion(id="sample_a", sample_type="Primary Tumor",),
                 SampleCriterion(id="sample_b", sample_type="Blood Derived Normal"),
             ],
-            case_id="case_1",
+            entity_id="case_1",
             maf_creation_date=datetime(2020, 1, 1),
         ),
         PrimaryAliquotSelectionCriterion(
@@ -60,7 +60,7 @@ def test_select_primary_aliquots__uses_maf_creation_date_to_break_tie():
                 SampleCriterion(id="sample_d", sample_type="Primary Tumor",),
                 SampleCriterion(id="sample_e", sample_type="Blood Derived Normal"),
             ],
-            case_id="case_1",
+            entity_id="case_1",
             maf_creation_date=datetime(2020, 1, 2),
         ),
     ]
@@ -77,7 +77,7 @@ def test_select_primary_aliquots__uses_maf_uuid_to_break_tie():
                 SampleCriterion(id="sample_a", sample_type="Primary Tumor",),
                 SampleCriterion(id="sample_b", sample_type="Blood Derived Normal"),
             ],
-            case_id="case_1",
+            entity_id="case_1",
             maf_creation_date=datetime(2020, 1, 1),
         ),
         PrimaryAliquotSelectionCriterion(
@@ -86,7 +86,7 @@ def test_select_primary_aliquots__uses_maf_uuid_to_break_tie():
                 SampleCriterion(id="sample_d", sample_type="Primary Tumor",),
                 SampleCriterion(id="sample_e", sample_type="Blood Derived Normal"),
             ],
-            case_id="case_1",
+            entity_id="case_1",
             maf_creation_date=datetime(2020, 1, 1),
         ),
     ]
@@ -103,7 +103,7 @@ def test_select_primary_aliquots__handles_multiple_cases():
                 SampleCriterion(id="sample_1", sample_type="Ectoplasm",),
                 SampleCriterion(id="sample_2", sample_type="Muslin"),
             ],
-            case_id="case_1",
+            entity_id="case_1",
             maf_creation_date=datetime(2020, 1, 1),
         ),
         PrimaryAliquotSelectionCriterion(
@@ -112,7 +112,7 @@ def test_select_primary_aliquots__handles_multiple_cases():
                 SampleCriterion(id="sample_3", sample_type="Primary Tumor",),
                 SampleCriterion(id="sample_4", sample_type="Blood Derived Normal",),
             ],
-            case_id="case_1",
+            entity_id="case_1",
             maf_creation_date=datetime(2020, 1, 1),
         ),
         PrimaryAliquotSelectionCriterion(
@@ -121,7 +121,7 @@ def test_select_primary_aliquots__handles_multiple_cases():
                 SampleCriterion(id="sample_5", sample_type="Unknown",),
                 SampleCriterion(id="sample_6", sample_type="Recurrent Tumor",),
             ],
-            case_id="case_2",
+            entity_id="case_2",
             maf_creation_date=datetime(2020, 1, 1),
         ),
     ]


### PR DESCRIPTION
Currently, PrimaryAliquotSelectionCriterion was selecting the primary aliquot per case_id. Now, with --disable-aliquot-selection feature in the gdc-maf-tool, the class was made more generic, as we now need to do primary aliquot selection per file. 